### PR TITLE
Added a `stylize()` convenience method.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -401,8 +401,8 @@ Or the convenient `stylize(text, *styles)` wrapper to save some keystrokes:
     >>> from colored import stylize
     >>> print(stylize("This is green.", colored.fg("green")))
     This is green.
-    >>> print("This isn't.")
-    This isn't.
+    >>> print("This is not.")
+    This is not.
     >>> angry = colored.fg("red") + colored.attr("bold")
     >>> print(stylize("This is angry text.", angry))
     This is angry text.

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,24 @@ Or use HEX code:
     >>> print (color + "Hello World !!!" + res)
     Hello World !!!
 
+Or the convenient `stylize(text, *styles)` wrapper to save some keystrokes:
+
+.. code-block:: bash
+
+    >>> import colored
+    >>> from colored import stylize
+    >>> print(stylize("This is green.", colored.fg("green")))
+    This is green.
+    >>> print("This isn't.")
+    This isn't.
+    >>> angry = colored.fg("red") + colored.attr("bold")
+    >>> print(stylize("This is angry text.", angry))
+    This is angry text.
+    >>> print(stylize("This is VERY angry text.", angry, colored.attr("underlined")))
+    This is VERY angry text.
+    >>> print("But this is not.")
+    But this is not.
+
 Use directly like `colorama <https://pypi.python.org/pypi/colorama>`_ but with more colors:
 
 .. code-block:: bash

--- a/colored/colored.py
+++ b/colored/colored.py
@@ -384,3 +384,8 @@ def fg(color):
 def bg(color):
     """alias for colored().background()"""
     return colored(color).background()
+
+
+def stylize(text, *styles):
+    """conveniently styles your text as and resets ANSI codes at its end."""
+    return "{}{}{}".format("".join(styles), text, attr("reset"))

--- a/colored/colored.py
+++ b/colored/colored.py
@@ -386,6 +386,7 @@ def bg(color):
     return colored(color).background()
 
 
-def stylize(text, *styles):
+def stylize(text, *styles, reset=True):
     """conveniently styles your text as and resets ANSI codes at its end."""
-    return "{}{}{}".format("".join(styles), text, attr("reset"))
+    terminator = attr("reset") if reset else ""
+    return "{}{}{}".format("".join(styles), text, terminator)


### PR DESCRIPTION
I'm using this in a custom `argparse.Formatter()` and I keep having to wrap statements in the ANSI shortcuts, so I just wrote a method that auto-resets after the string. You can use an arbitrary number of args to list styles or mix and match as desired.